### PR TITLE
if no filename is given will read off stdin by default

### DIFF
--- a/show_struct.py
+++ b/show_struct.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # vim: ts=4 sw=4 et
 
+# https://github.com/ilyash/show-struct.git
+
 import argparse
 import collections
 import json
-
+import sys
 
 class Outliner(object):
 
@@ -44,11 +46,14 @@ class Outliner(object):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('Show structure of give JSON file')
-    parser.add_argument('file', metavar='FILE')
+    parser.add_argument('file', metavar='FILE',help="The filename to read. Use '-' to read stdin - defaults to '-'",default="-",nargs="?")
     args = parser.parse_args()
 
-    with open(args.file) as f:
-        data = json.loads(f.read())
+    if args.file == "-":
+        data = json.loads(sys.stdin.read())
+    else:
+        with open(args.file) as f:
+            data = json.loads(f.read())
 
     outline = Outliner().outline(data)
     for path in outline:


### PR DESCRIPTION
more convenient than the last one - makes it natural to use in pipelines
